### PR TITLE
Fix deprecation warnings on run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 PROVIDER_VERSION=1.7.0
 
 # Pulumi bridged provider version (this package)
-VERSION=1.7.0
+VERSION=1.7.1
 
 default: build
 

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@tetratelabs/pulumi-checkmate",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": ". Based on terraform-provider-checkmate: version v1.7.0",
-  "main": "ts_bin/index.js",
-  "types": "ts_bin/index.d.ts",
+  "types": "dist/index.d.ts",
+  "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
     "prepare": "npm run build",
-    "install": "node sdk/scripts/install-pulumi-plugin.js resource checkmate 1.7.0 --server github://api.github.com/tetratelabs"
+    "install": "node sdk/scripts/install-pulumi-plugin.js resource checkmate 1.7.1 --server github://api.github.com/tetratelabs"
   },
   "dependencies": {
     "@pulumi/pulumi": "^3.0.0"

--- a/package.json.tpl
+++ b/package.json.tpl
@@ -2,8 +2,8 @@
   "name": "@tetratelabs/pulumi-checkmate",
   "version": "${VERSION}",
   "description": ". Based on terraform-provider-checkmate: version v${PROVIDER_VERSION}",
-  "main": "ts_bin/index.js",
-  "types": "ts_bin/index.d.ts",
+  "types": "dist/index.d.ts",
+  "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
     "prepare": "npm run build",

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -52,7 +52,7 @@ func Provider() tfbridge.ProviderInfo {
 		Name:              "checkmate",
 		GitHubOrg:         "tetratelabs",
 		TFProviderVersion: "1.7.0",
-		Version:           "1.7.0",
+		Version:           "1.7.1",
 		Resources: map[string]*tfbridge.ResourceInfo{
 			"checkmate_http_health":   {Tok: checkResourceTok(checkMod, "HttpHealth")},
 			"checkmate_local_command": {Tok: checkResourceTok(checkMod, "LocalCommand")},

--- a/sdk/scripts/install-pulumi-plugin.js
+++ b/sdk/scripts/install-pulumi-plugin.js
@@ -17,7 +17,7 @@ var childProcess = require("child_process");
 
 var args = process.argv.slice(2);
 
-if (args.indexOf("v1.7.0") !== -1) {
+if (args.indexOf("v1.7.1") !== -1) {
 	process.exit(0);
 }
 


### PR DESCRIPTION
`types` and `main` were in the wrong places. not sure how it was still working